### PR TITLE
Stop using t test for sample size

### DIFF
--- a/man/get_p_values_matrix.Rd
+++ b/man/get_p_values_matrix.Rd
@@ -4,23 +4,13 @@
 \alias{get_p_values_matrix}
 \title{Generate P-Values Matrix from Model Coefficient Simulations}
 \usage{
-get_p_values_matrix(
-  model,
-  n_sim = 1000,
-  use_tstat = NULL,
-  test_coefficients = NULL,
-  ...
-)
+get_p_values_matrix(model, n_sim = 1000, test_coefficients = NULL, ...)
 }
 \arguments{
 \item{model}{A model with \code{\link[=update]{update()}}, \code{\link[=simulate]{simulate()}}, \code{\link[=fitted]{fitted()}},
 \code{\link[=coef]{coef()}}, \code{\link[=vcov]{vcov()}} methods.}
 
 \item{n_sim}{The number of simulations to perform.}
-
-\item{use_tstat}{Logical. If TRUE, the t-statistic is used for computing p-values.
-If FALSE, the z-statistic is used. If NULL, the default is determined based on
-the presence of the "t value" column in the summary of the model coefficients.}
 
 \item{test_coefficients}{Numeric vector. A vector with values to be used to compute
 the test statistic. It should be the coefficients that was used to compute

--- a/tests/testthat/test-sample_size.R
+++ b/tests/testthat/test-sample_size.R
@@ -8,21 +8,6 @@ test_that("simulate_coefficients() returns a list with two components", {
   expect_named(simulation_result, c("coefs", "vcov"))
 })
 
-test_that("use_tstat yield different results", {
-  x <- c(1, 3, 5, 7)
-  y <- c(2, 3, 6, 9)
-  fit <- lm(y ~ x)
-  set.seed(1)
-  matrix_null <- get_p_values_matrix(fit, n_sim = 10, use_tstat = NULL)
-  set.seed(1)
-  matrix_true <- get_p_values_matrix(fit, n_sim = 10, use_tstat = TRUE)
-  set.seed(1)
-  matrix_false <- get_p_values_matrix(fit, n_sim = 10, use_tstat = FALSE)
-
-  expect_identical(matrix_true, matrix_null)
-  expect_false(identical(matrix_true, matrix_false))
-})
-
 test_that("test_coefficients generate different results", {
   x <- c(1, 3, 5, 7)
   y <- c(2, 3, 6, 9)


### PR DESCRIPTION
As the goal is to verify if the Normal approximation is valid, t test will no longer be used.